### PR TITLE
Allow for market orders

### DIFF
--- a/modules/listener/tick_listener.js
+++ b/modules/listener/tick_listener.js
@@ -114,7 +114,7 @@ module.exports = class TickListener {
         }, signal, strategyKey);
         this.notified[noteKey] = new Date();
 
-        await this.pairStateManager.update(symbol.exchange, symbol.symbol, signal)
+        await this.pairStateManager.update(symbol.exchange, symbol.symbol, signal, strategy['options'] || {})
     }
 
     async onTick() {


### PR DESCRIPTION
I found that the option to activate market orders was not otherwise available to be activated if I am not mistaken and with this change it can be set in the strategy options.