### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "sendmail": "^1.4.1",
     "sqlite3": "^4.0.3",
     "sqlite3-transactions": "0.0.5",
-    "talib": "^1.0.5",
+    "talib": "1.0.7",
     "technicalindicators": "^2.0.9",
     "telegraf": "^3.29.0",
     "tulind": "^0.8.15",


### PR DESCRIPTION
Every newer talib version than "talib": "1.0.7" ends with build error.