### PR TITLE
Fix folderDir parameter is not passed to StrategyManager constructor

### DIFF
--- a/src/modules/services.js
+++ b/src/modules/services.js
@@ -351,7 +351,8 @@ module.exports = {
     return (strategyManager = new StrategyManager(
       this.getTechnicalAnalysisValidator(),
       this.getExchangeCandleCombine(),
-      this.getLogger()
+      this.getLogger(),
+      parameters.projectDir
     ));
   },
 


### PR DESCRIPTION
Hi, 

I've noticed that folderDir parameter is not passed to StrategyManager constructor.
This leads to custom strategies are not fetched form /var/strategies/ folder.

This small fix fixes the problem.

Cheers!