### PR TITLE
Enable short/long trades without exit of open trade

### DIFF
--- a/src/dict/exchange_position.js
+++ b/src/dict/exchange_position.js
@@ -3,7 +3,7 @@ const Position = require('./position');
 module.exports = class ExchangePosition {
   constructor(exchange, position) {
     if (!(position instanceof Position)) {
-      throw 'TypeError: invalid position';
+      throw new Error(`TypeError: invalid position`);
     }
 
     this._exchange = exchange;
@@ -11,7 +11,7 @@ module.exports = class ExchangePosition {
   }
 
   getKey() {
-    return this._exchange + this._position.symbol;
+    return this._exchange + this._position.symbol + this._position.side;
   }
 
   getExchange() {


### PR DESCRIPTION
Tradingview allows strategies to switch long/short without exit of current position. 
This update allow same thing. It checks if there is open position, then if we want to switch from side, it adds position amount to calculated order size.
This works on Bitfinex, have not tested on other exchanges.

I had doupts if this should be added directly in executeOrder method, or in CalculateOrderSize.
But was bit afraid to touch it.