### PR TITLE
fix eslint setting for end lines

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
   "singleQuote": true,
   "printWidth": 120,
-  "endOfLine": "lf"
+  "endOfLine": "crlf"
 }


### PR DESCRIPTION
Partly fixes issue #109 
prettier parameter was set to LF, but all files are saved with CRLF endings.
this generates lots of errors.