### PR TITLE
Fix projectDir in backtest

### DIFF
--- a/src/modules/backtest.js
+++ b/src/modules/backtest.js
@@ -4,10 +4,11 @@ const StrategyManager = require('./strategy/strategy_manager');
 const Resample = require('../utils/resample');
 
 module.exports = class Backtest {
-  constructor(instances, strategyManager, exchangeCandleCombine) {
+  constructor(instances, strategyManager, exchangeCandleCombine, projectDir) {
     this.instances = instances;
     this.strategyManager = strategyManager;
     this.exchangeCandleCombine = exchangeCandleCombine;
+    this.projectDir = projectDir;
   }
 
   getBacktestPairs() {
@@ -69,7 +70,7 @@ module.exports = class Backtest {
 
       const end = moment().unix();
       while (current < end) {
-        const strategyManager = new StrategyManager({}, mockedRepository);
+        const strategyManager = new StrategyManager({}, mockedRepository, {}, this.projectDir);
 
         const item = await strategyManager.executeStrategyBacktest(strategy, exchange, pair, options, lastSignal);
         item.time = current;

--- a/src/modules/services.js
+++ b/src/modules/services.js
@@ -170,7 +170,7 @@ module.exports = {
       return backtest;
     }
 
-    return (backtest = new Backtest(this.getInstances(), this.getStrategyManager(), this.getExchangeCandleCombine()));
+    return (backtest = new Backtest(this.getInstances(), this.getStrategyManager(), this.getExchangeCandleCombine(), parameters.projectDir));
   },
 
   getStopLossCalculator: function() {


### PR DESCRIPTION
One more fix related to projectDir.
Backtest page was unable to find custom strategies.
