### PR TITLE
fix backtest page, signals table showed wrong data

### DIFF
--- a/templates/backtest_submit.html.twig
+++ b/templates/backtest_submit.html.twig
@@ -51,7 +51,7 @@
                             <!-- /.card-header -->
                             <div class="card-body table-responsive p-0">
                                 {% include 'components/backtest_table.html.twig' with {
-                                    'rows': rows,
+                                    'rows': signals,
                                     'extra_fields': extra_fields,
                                 } only %}
                             </div>


### PR DESCRIPTION
Small fix to bactkest results page, signals table shows same data as bottom table (rows).