### PR TITLE
bitfinex option to trade percent of balance

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ You should only provide one of them, first wins.
         'trade': {
             'capital': 0.015, // this will buy 0.015 BTC
             'currency_capital': 50,  // this will use 50 EUR and buys the equal amount of BTC (example: BTC price 3000 use 50 EUR. will result in 0.016 BTC)
+            'balance_percent': 75,  // this will use 75 % of your exchange margin tradable balance. Currently implemented only on Bitfinex exchange.
         },
     })
 ```

--- a/src/dict/order_capital.js
+++ b/src/dict/order_capital.js
@@ -7,6 +7,10 @@ module.exports = class OrderCapital {
     return 'currency';
   }
 
+  static get BALANCE() {
+    return 'balance';
+  }
+
   static createAsset(asset) {
     const capital = new OrderCapital();
     capital.type = OrderCapital.ASSET;
@@ -21,13 +25,24 @@ module.exports = class OrderCapital {
     return capital;
   }
 
+  static createBalance(balance) {
+    const capital = new OrderCapital();
+    capital.type = OrderCapital.BALANCE;
+    capital.balance = balance;
+    return capital;
+  }
+
   getAmount() {
     if (this.type === OrderCapital.CURRENCY) {
-      return this.currency;
+      return this.getCurrency();
     }
 
     if (this.type === OrderCapital.ASSET) {
-      return this.asset;
+      return this.getAsset();
+    }
+
+    if (this.type === OrderCapital.BALANCE) {
+      return this.getBalance();
     }
 
     throw new Error(`Invalid capital type:${this.type}`);
@@ -39,5 +54,9 @@ module.exports = class OrderCapital {
 
   getCurrency() {
     return this.currency;
+  }
+
+  getBalance() {
+    return this.balance;
   }
 };

--- a/src/exchange/bitfinex.js
+++ b/src/exchange/bitfinex.js
@@ -496,6 +496,10 @@ module.exports = class Bitfinex {
     return false;
   }
 
+  getTradableBalance() {
+    return this.balanceInfo ? this.balanceInfo.amountNet : undefined;
+  }
+
   /**
    * Connect to websocket on chunks because Bitfinex limits per connection subscriptions eg to 30
    *
@@ -677,6 +681,11 @@ module.exports = class Bitfinex {
 
     ws.onPositionClose({}, position => {
       me.onPositionUpdate(position);
+    });
+
+    ws.onBalanceInfoUpdate({}, balanceInfo => {
+      this.logger.debug(`BalanceInfoUpdate updtate: ${JSON.stringify(balanceInfo)}`);
+      this.balanceInfo = balanceInfo;
     });
 
     ws.open();

--- a/src/modules/pairs/pair_config.js
+++ b/src/modules/pairs/pair_config.js
@@ -32,6 +32,17 @@ module.exports = class PairConfig {
       return OrderCapital.createCurrency(capitalCurrency.trade.currency_capital);
     }
 
+    const balancePercent = this.instances.symbols.find(
+      instance =>
+        instance.exchange === exchangeName &&
+        instance.symbol === symbol &&
+        _.get(instance, 'trade.balance_percent', 0) > 0
+    );
+
+    if (balancePercent) {
+      return OrderCapital.createBalance(balancePercent.trade.balance_percent);
+    }
+
     return undefined;
   }
 };


### PR DESCRIPTION
Set pair to trade percent of available tradable balance (can be set above 100% for leverage trades).
Implemented only for Bitfinex so far, but I believe also possible to implement on other exchanges.

```
       'trade': {
            'capital': 0.015, // this will buy 0.015 BTC
            'currency_capital': 50,  // this will use 50 EUR and buys the equal amount of BTC (example: BTC price 3000 use 50 EUR. will result in 0.016 BTC)
            'balance_percent': 75,  // this will use 75 % of your exchange margin tradable balance. Currently implemented only on Bitfinex exchange.
        },
 
```