### PR TITLE
fix getPivotPointsWithWicks according TradingView pivothigh/pivotlow functions

### DIFF
--- a/src/utils/technical_analysis.js
+++ b/src/utils/technical_analysis.js
@@ -212,7 +212,7 @@ module.exports = {
       if (
         ['close', 'high'].includes(source) &&
         typeof leftRange.find(c => c[source] > middleValue) === 'undefined' &&
-        typeof rightRange.find(c => c[source] > middleValue) === 'undefined'
+        typeof rightRange.find(c => c[source] >= middleValue) === 'undefined'
       ) {
         if (!result.high) {
           result.high = {};
@@ -224,7 +224,7 @@ module.exports = {
       if (
         ['close', 'low'].includes(source) &&
         typeof leftRange.find(c => c[source] < middleValue) === 'undefined' &&
-        typeof rightRange.find(c => c[source] < middleValue) === 'undefined'
+        typeof rightRange.find(c => c[source] <= middleValue) === 'undefined'
       ) {
         if (!result.low) {
           result.low = {};


### PR DESCRIPTION
I noticed that TV calculates a slightly different pivothigh/pivotlow. Here is the fix.
I found Metatrader fractal algorithm which works identical to TV[ here](https://www.mql5.com/en/code/1381), MQL5 code is [here](https://www.mql5.com/en/code/viewcode/1381/128668/x-bars_fractals.mq5).
