### PR TITLE
Fix trade balance percent bug

### DIFF
--- a/src/modules/order/order_calculator.js
+++ b/src/modules/order/order_calculator.js
@@ -19,23 +19,22 @@ module.exports = class OrderCalculator {
    * @returns {Promise<?Number>}
    */
   async calculateOrderSizeCapital(exchangeName, symbol, capital) {
-    const asset = capital.getAsset();
-    const currency = capital.getCurrency();
     const balancePercent = capital.getBalance();
-
-    if (!asset && !currency && !balancePercent) {
-      throw new Error(`Invalid capital`);
-    }
-
     const exchange = this.exchangeManager.get(exchangeName);
 
-    let amountCurrency = balancePercent ? (exchange.getTradableBalance() * balancePercent) / 100 : currency;
-    let amountAsset = asset;
+    let amountAsset = capital.getAsset();
+    let amountCurrency = balancePercent
+      ? (exchange.getTradableBalance() * balancePercent) / 100
+      : capital.getCurrency();
+
+    if (!amountAsset && !amountCurrency) {
+      throw new Error(`Invalid capital`);
+    }
     if (!amountAsset) {
       amountAsset = await this.convertCurrencyToAsset(exchangeName, symbol, amountCurrency);
     }
     if (!amountCurrency) {
-      amountCurrency = await this.convertAssetToCurrency(exchangeName, symbol, asset);
+      amountCurrency = await this.convertAssetToCurrency(exchangeName, symbol, amountAsset);
     }
     return exchange.calculateAmount(exchange.isInverseSymbol(symbol) ? amountCurrency : amountAsset, symbol);
   }

--- a/src/modules/pairs/pairs_http.js
+++ b/src/modules/pairs/pairs_http.js
@@ -19,15 +19,18 @@ module.exports = class PairsHttp {
 
         const tradeCapital = _.get(symbol, 'trade.capital', 0);
         const tradeCurrencyCapital = _.get(symbol, 'trade.currency_capital', 0);
+        const tradeBalancePercent = _.get(symbol, 'trade.balance_percent', 0);
 
         const item = {
           exchange: symbol.exchange,
           symbol: symbol.symbol,
           watchdogs: symbol.watchdogs,
-          is_trading: strategiesTrade.length > 0 || tradeCapital > 0 || tradeCurrencyCapital > 0,
+          is_trading:
+            strategiesTrade.length > 0 || tradeCapital > 0 || tradeCurrencyCapital > 0 || tradeBalancePercent > 0,
           has_position: position !== undefined,
           trade_capital: tradeCapital,
           trade_currency_capital: tradeCurrencyCapital,
+          trade_balance_percent: tradeBalancePercent,
           strategies: strategies,
           strategies_trade: strategiesTrade,
           weight: 0,

--- a/templates/pairs.html.twig
+++ b/templates/pairs.html.twig
@@ -68,7 +68,7 @@
                                                 <td class="no-wrap"><img src="/img/exchanges/{{ pair.exchange }}.png" title="{{ pair.exchange }}" alt="{{ pair.exchange }}" width="16px" height="16px"></td>
                                                 <td class="no-wrap row-pair"><a target="blank" href="/tradingview/{{ pair.exchange }}:{{ pair.symbol }}">{{ pair.symbol }}</td>
                                                 <td class="no-wrap">{{ pair.is_trading ? '<i class="fas fa-cart-plus font-weight-bold" title="Trade"></i>' : '<i class="fas fa-eye text-muted" title="Watch"></i>' }}</td>
-                                                <td class="no-wrap">{% if pair.is_trading %}{{ pair.trade_capital|default(0) }} / {{ pair.trade_currency_capital|default(0) }} {% endif %}</td>
+                                                <td class="no-wrap">{% if pair.is_trading %}{{ pair.trade_capital|default(0) }} / {{ pair.trade_currency_capital|default(0) }} / {{ pair.trade_balance_percent|default(0) }}% {% endif %}</td>
                                                 <td class="text-muted"><span class="span-md">{% if pair.strategies.length > 0 %}{{ pair.strategies|json_encode }}{% endif %}</span></td>
                                                 <td class="text-muted"><span class="span-md">{% if pair.strategies_trade.length > 0 %}{{ pair.strategies_trade|json_encode }}{% endif %}</span></td>
                                                 <td class="text-muted">
@@ -80,7 +80,7 @@
                                                 </td>
                                                 <td style="white-space: nowrap">{{ pair.process }}</td>
                                                 <td class="text-right"  style="white-space: nowrap">
-                                                    {% if pair.trade_capital > 0 or pair.trade_currency_capital > 0 %}
+                                                    {% if pair.trade_capital > 0 or pair.trade_currency_capital > 0 or pair.trade_balance_percent > 0 %}
                                                         <form action="/pairs/{{ pair.exchange }}-{{ pair.symbol }}" method="post" style="margin:0; padding:0">
                                                             <div class="btn-group btn-group-sm">
                                                                 {% if pair.has_position|default(false) == false and not pair.process %}

--- a/test/modules/order/order_calculator.test.js
+++ b/test/modules/order/order_calculator.test.js
@@ -3,110 +3,21 @@ const OrderCalculator = require('../../../src/modules/order/order_calculator');
 const PairConfig = require('../../../src/modules/pairs/pair_config');
 
 describe('#order size calculation', () => {
-  it('test instance order size for capital', async () => {
-    const instances = {};
-
-    instances.symbols = [
-      {
-        exchange: 'foobar',
-        symbol: 'foo',
-        trade: {
-          capital: 12
-        }
-      },
-      {
-        exchange: 'foobar2',
-        symbol: 'foo2'
-      },
-      {
-        exchange: 'foobar',
-        symbol: 'foo2',
-        trade: {
-          capital: 1337
-        }
+  const testTickers = {
+    get(exchangeName, symbol) {
+      if (symbol === 'foo') {
+        return { bid: 3000 };
       }
-    ];
 
-    const calculator = new OrderCalculator(
-      {},
-      {
-        error: () => {}
-      },
-      {
-        get: () => {
-          return {
-            calculateAmount: n => n,
-            isInverseSymbol: () => false
-          };
-        }
-      },
-      new PairConfig(instances)
-    );
-
-    assert.strictEqual(await calculator.calculateOrderSize('foobar', 'foo'), 12);
-    assert.strictEqual(await calculator.calculateOrderSize('UNKNOWN', 'foo'), undefined);
-    assert.strictEqual(await calculator.calculateOrderSize('foobar', 'foo2'), 1337);
-  });
-
-  it('test instance order size currency capital', async () => {
-    const instances = {};
-
-    instances.symbols = [
-      {
-        exchange: 'foobar',
-        symbol: 'foo',
-        trade: {
-          currency_capital: 12
-        }
-      },
-      {
-        exchange: 'foobar2',
-        symbol: 'foo2'
-      },
-      {
-        exchange: 'foobar',
-        symbol: 'foo2',
-        trade: {
-          currency_capital: 1337
-        }
+      if (symbol === 'foo2') {
+        return { bid: 6000 };
       }
-    ];
 
-    const calculator = new OrderCalculator(
-      {
-        get: (exchangeName, symbol) => {
-          if (symbol === 'foo') {
-            return { bid: 3000 };
-          }
-
-          if (symbol === 'foo2') {
-            return { bid: 6000 };
-          }
-        }
-      },
-      {
-        error: () => {}
-      },
-      {
-        get: () => {
-          return {
-            calculateAmount: n => n,
-            isInverseSymbol: () => false
-          };
-        }
-      },
-      new PairConfig(instances)
-    );
-
-    assert.strictEqual(await calculator.calculateOrderSize('foobar', 'foo'), 0.004);
-    assert.strictEqual(await calculator.calculateOrderSize('UNKNOWN', 'foo'), undefined);
-    assert.strictEqual((await calculator.calculateOrderSize('foobar', 'foo2')).toFixed(2), '0.22');
-  });
-
-  it('test instance order size fir inverse exchanges', async () => {
-    const instances = {};
-
-    instances.symbols = [
+      return { bid: 8000 };
+    }
+  };
+  const instances = {
+    symbols: [
       {
         exchange: 'foobar',
         symbol: 'foo',
@@ -134,40 +45,82 @@ describe('#order size calculation', () => {
       },
       {
         exchange: 'foobar',
+        symbol: 'foo_capital2',
+        trade: {
+          capital: 12
+        }
+      },
+      {
+        exchange: 'foobar',
+        symbol: 'foo_capital3',
+        trade: {
+          capital: 1337
+        }
+      },
+      {
+        exchange: 'foobar',
         symbol: 'foo_balance',
         trade: {
           balance_percent: 50
         }
       }
-    ];
+    ]
+  };
 
+  it('test instance order size for capital', async () => {
     const calculator = new OrderCalculator(
-      {
-        get: (exchangeName, symbol) => {
-          if (symbol === 'foo') {
-            return { bid: 3000 };
-          }
-
-          if (symbol === 'foo2') {
-            return { bid: 6000 };
-          }
-
-          if (symbol === 'foo_capital') {
-            return { bid: 8000 };
-          }
-
-          if (symbol === 'foo_balance') {
-            return { bid: 8000 };
-          }
-        }
-      },
+      testTickers,
       {
         error: () => {}
       },
       {
         get: () => {
           return {
-            getBalance: () => 100,
+            calculateAmount: n => n,
+            isInverseSymbol: () => false
+          };
+        }
+      },
+      new PairConfig(instances)
+    );
+
+    assert.strictEqual(await calculator.calculateOrderSize('foobar', 'foo_capital2'), 12);
+    assert.strictEqual(await calculator.calculateOrderSize('UNKNOWN', 'foo'), undefined);
+    assert.strictEqual(await calculator.calculateOrderSize('foobar', 'foo_capital3'), 1337);
+  });
+
+  it('test instance order size currency capital', async () => {
+    const calculator = new OrderCalculator(
+      testTickers,
+      {
+        error: () => {}
+      },
+      {
+        get: () => {
+          return {
+            calculateAmount: n => n,
+            isInverseSymbol: () => false
+          };
+        }
+      },
+      new PairConfig(instances)
+    );
+
+    assert.strictEqual(await calculator.calculateOrderSize('foobar', 'foo'), 0.004);
+    assert.strictEqual(await calculator.calculateOrderSize('UNKNOWN', 'foo'), undefined);
+    assert.strictEqual((await calculator.calculateOrderSize('foobar', 'foo2')).toFixed(2), '0.22');
+  });
+
+  it('test instance order size for inverse exchanges', async () => {
+    const calculator = new OrderCalculator(
+      testTickers,
+      {
+        error: () => {}
+      },
+      {
+        get: () => {
+          return {
+            getTradableBalance: () => 100,
             calculateAmount: n => n,
             isInverseSymbol: () => true
           };
@@ -181,59 +134,5 @@ describe('#order size calculation', () => {
     assert.strictEqual(await calculator.calculateOrderSize('foobar', 'foo2'), 1337.0);
     assert.strictEqual(await calculator.calculateOrderSize('foobar', 'foo_capital'), 0.8);
     assert.strictEqual(await calculator.calculateOrderSize('foobar', 'foo_balance'), 50);
-  });
-
-  it('test instance order size for balance percent', async () => {
-    const instances = {};
-
-    instances.symbols = [
-      {
-        exchange: 'foobar',
-        symbol: 'foo',
-        trade: {
-          balance_percent: 100
-        }
-      },
-      {
-        exchange: 'foobar2',
-        symbol: 'foo2'
-      },
-      {
-        exchange: 'foobar',
-        symbol: 'foo2',
-        trade: {
-          balance_percent: 50
-        }
-      },
-      {
-        exchange: 'foobar',
-        symbol: 'foo3',
-        trade: {
-          balance_percent: 150
-        }
-      }
-    ];
-
-    const calculator = new OrderCalculator(
-      {},
-      {
-        error: () => {}
-      },
-      {
-        get: () => {
-          return {
-            getBalance: () => 100,
-            calculateAmount: n => n / 10,
-            isInverseSymbol: () => false
-          };
-        }
-      },
-      new PairConfig(instances)
-    );
-
-    assert.strictEqual(await calculator.calculateOrderSize('foobar', 'foo'), 10);
-    assert.strictEqual(await calculator.calculateOrderSize('UNKNOWN', 'foo'), undefined);
-    assert.strictEqual(await calculator.calculateOrderSize('foobar', 'foo2'), 5);
-    assert.strictEqual(await calculator.calculateOrderSize('foobar', 'foo3'), 15);
   });
 });


### PR DESCRIPTION
There was bug in #144. Strategy did not work because of wrong function name. 
Bitfinex strategy provides method getTradableBalance():
https://github.com/Haehnchen/crypto-trading-bot/blob/e7b2a7fab19b546cc30d0ea77c08d493eb3d8ce7/src/exchange/bitfinex.js#L509

but  order_calculator was calling getBalance() function here:
https://github.com/Haehnchen/crypto-trading-bot/blob/e7b2a7fab19b546cc30d0ea77c08d493eb3d8ce7/src/modules/order/order_calculator.js#L39
and here: 
https://github.com/Haehnchen/crypto-trading-bot/blob/e7b2a7fab19b546cc30d0ea77c08d493eb3d8ce7/src/modules/order/order_calculator.js#L51

Second problem that getTradableBalance return amount in currency and it has to be converted to Asset.

 I lost few hundred bucs because of  my own bug :) 

1. Fixed bug, refactored price calculation method to be more generic and compact: calculate both prices in asset and currency and return needed one based on exchange.
2. fixed unit test.
3. Also noticed that balance percent strategies did not allow actions in Pairs page and did not show percentage. Implemented this in second commit.
