### PR TITLE
Fixing STOP LIMIT Order for FTX Exchange

### DIFF
--- a/src/exchange/ftx.js
+++ b/src/exchange/ftx.js
@@ -81,6 +81,19 @@ module.exports = class Ftx {
         return CcxtUtil.createExchangeOrders(
           (await client.privateGetConditionalOrders()).result.map(r => client.parseOrder(r))
         );
+      },
+      createOrder: order => {
+        const request = {
+          args: {}
+        };
+
+        if (order.isReduceOnly()) {
+          request.args.reduceOnly = true;
+        }
+
+        if (order.getType() === Order.TYPE_STOP) {
+          request.args.stopPrice = order.getPrice();
+        }
       }
     });
 


### PR DESCRIPTION
Added 'stopPrice' to request as mentioned in CCXT :[https://github.com/ccxt/ccxt/blob/master/python/ccxt/ftx.py](url)
`raise ArgumentsRequired(self.id + ' createOrder() requires a stopPrice parameter or a triggerPrice parameter for ' + type + ' orders')`

Otherwise stop loss does not work for FTX Exchange.
