### PR TITLE
add: refactor backtesting to a different fork

### DIFF
--- a/src/command/backtest.js
+++ b/src/command/backtest.js
@@ -1,0 +1,23 @@
+const services = require('../modules/services');
+
+process.on('message', async msg => {
+  const p = msg.pair.split('.');
+
+  const results = await services
+    .getBacktest()
+    .getBacktestResult(
+      msg.tickIntervalInMinutes,
+      msg.hours,
+      msg.strategy,
+      msg.candlePeriod,
+      p[0],
+      p[1],
+      msg.options,
+      msg.initialCapital,
+      msg.projectDir
+    );
+
+  process.send({
+    results: results
+  });
+});

--- a/src/modules/services.js
+++ b/src/modules/services.js
@@ -155,7 +155,7 @@ module.exports = {
     myDb.pragma('journal_mode = WAL');
 
     myDb.pragma('SYNCHRONOUS = 1;');
-    myDb.pragma('LOCKING_MODE = EXCLUSIVE;');
+    // myDb.pragma('LOCKING_MODE = EXCLUSIVE;');
 
     return (db = myDb);
   },

--- a/templates/backtest-pending-results.html.twig
+++ b/templates/backtest-pending-results.html.twig
@@ -1,0 +1,65 @@
+{% extends './layout.html.twig' %}
+
+{% block title %}Backtesting | Crypto Bot{% endblock %}
+
+{% block content %}
+    <!-- Content Wrapper. Contains page content -->
+    <div class="content-wrapper">
+        <!-- Content Header (Page header) -->
+        <section class="content-header">
+            <div class="container">
+                <div class="row mb-2">
+                    <div class="col-sm-6">
+                        <h1>Backtesting</h1>
+                    </div>
+                    <div class="col-sm-6">
+                        <ol class="breadcrumb float-sm-right">
+                            <li class="breadcrumb-item"><a href="{{ '/' }}">Dashboard</a></li>
+                            <li class="breadcrumb-item active">Backtesting</li>
+                        </ol>
+                    </div>
+                </div>
+            </div><!-- /.container-fluid -->
+        </section>
+        <!-- /.Content Header (Page header) -->
+
+        <!-- Main content -->
+        <div class="content">
+            <div class="container">
+                <h3>Waiting results for backtest id {{ key }}</h3>
+            </div><!-- /.container-fluid -->
+        </div>
+        <!-- /.content -->
+    </div>
+    <!-- /.content-wrapper -->
+
+{% endblock %}
+
+{% block javascript %}
+<script src="/js/backtest-form.js?v={{ asset_version() }}"></script>
+<script>
+var ready = false;
+const intervalId = setInterval(call, 2000);
+function call() {
+      $.ajax({
+        type: "GET",
+        url: '/backtest/{{ key }}',
+        dataType: "json",
+        success: function(data, textStatus) {
+          ready = data.ready;
+          if (data.ready === true) {
+            clearInterval(intervalId);
+            window.location.href = '/backtest/result/{{ key }}'
+          }
+        }
+    })
+};
+
+</script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/chosen/1.8.7/chosen.jquery.min.js" integrity="sha512-rMGGF4wg1R73ehtnxXBt5mbUfN9JUJwbk21KMlnLZDJh7BkPmeovBuddZCENJddHYYMkCh9hPFnPmS9sspki8g==" crossorigin="anonymous"></script>
+{% endblock %}
+
+{% block stylesheet %}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/chosen/1.8.7/chosen.min.css" integrity="sha512-yVvxUQV0QESBt1SyZbNJMAwyKvFTLMyXSyBHDO4BG5t7k/Lw34tyqlSDlKIrIENIzCl+RVUNjmCPG+V/GMesRw==" crossorigin="anonymous" />
+{% endblock %}

--- a/templates/backtest_submit.html.twig
+++ b/templates/backtest_submit.html.twig
@@ -45,7 +45,7 @@
                             <!-- /.card-body -->
                         </div>
                         <!-- /.card -->
-                        
+
                         <div class="card">
                             <div class="card-header">
                                 <h3 class="card-title">Chart</h3>
@@ -83,10 +83,14 @@
                             </div>
                             <!-- /.card-header -->
                             <div class="card-body table-responsive p-0">
-                                {% include 'components/backtest_table.html.twig' with {
-                                    'rows': rows,
-                                    'extra_fields': extra_fields,
-                                } only %}
+                                {% if rows|length > 1000 %}
+                                    {% include 'components/backtest_table.html.twig' with {
+                                        'rows': rows,
+                                        'extra_fields': extra_fields,
+                                    } only %}
+                                {% else %}
+                                    <span style="margin: 10px">Too many rows detected, rendering process skipped.</span>
+                                {% endif %}
                             </div>
                             <!-- /.card-body -->
                         </div>

--- a/templates/components/backtest_table.html.twig
+++ b/templates/components/backtest_table.html.twig
@@ -21,7 +21,7 @@
             <td class="no-wrap">{{ row.price|default }}</td>
             <td class="no-wrap">
                 {% if row.profit is defined %}
-                    <span class="{{ row.profit > 0 ? 'text-success' : 'text-danger' }} {{ row.result.signal|default == 'close' ? ' font-weight-bold' : '' }}">{{ row.profit|round(2) }} %</span>
+                    <span class="{{ row.profit > 0 ? 'text-success' : 'text-danger' }} {{ row.result._signal|default == 'close' ? ' font-weight-bold' : '' }}">{{ row.profit|round(2) }} %</span>
                 {% endif %}
 
                 {% if row.lastPriceClosed is defined %}
@@ -30,11 +30,11 @@
             </td>
             <td>
                 {% if row.result is defined %}
-                    {% if row.result.signal == 'long' %}
+                    {% if row.result._signal == 'long' %}
                         <i class="fas fa-chevron-circle-up text-success"></i>
-                    {% elseif row.result.signal == 'short' %}
+                    {% elseif row.result._signal == 'short' %}
                         <i class="fas fa-chevron-circle-down text-danger"></i>
-                    {% elseif row.result.signal == 'close' %}
+                    {% elseif row.result._signal == 'close' %}
                         <i class="fa fa-times"></i>
                     {% endif %}
                 {% endif %}


### PR DESCRIPTION
This commit updates backtesting to be executed in a different fork, it allows to start up several different executions independently, either by different tabs or even different pairs at the same time.

In the future, this process could be persisted in database with the intention of running long backtestings of years of information on several dozen pairs.

The exclusive locking had to be disabled so that each fork also has access to transact with the database. It would be interesting to move it to a Postgres, including a potential docker file