### PR TITLE
fix(telegraf): Telegraf is not a constructor

### DIFF
--- a/src/modules/services.js
+++ b/src/modules/services.js
@@ -741,7 +741,7 @@ module.exports = {
   },
 
   createTelegram: function() {
-    const Telegraf = require('telegraf');
+    const { Telegraf } = require('telegraf');
     const config = this.getConfig();
     const { token } = config.notify.telegram;
 


### PR DESCRIPTION
Hi, this PR fixes the error `[error] uncaughtException: Telegraf is not a constructor`.